### PR TITLE
Use an interface for the GitHub cli allowing dependency injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `--fake-github-cli` flag to use a fake/mock GitHub Cli instead of the real one, this allows more intelligent tests without making any API calls at all
+
 ## [0.2.1] - 2024-02-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # GitHub Workflow Parser
 
+- [GitHub Workflow Parser](#github-workflow-parser)
+- [Purpose](#purpose)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Example of a created issue's body](#example-of-a-created-issues-body)
+    - [`Test template xilinx` (ID 21442749267)](#test-template-xilinx-id-21442749267)
+- [Code documentation](#code-documentation)
+
+
 # Purpose
 
 Make automatic issue creation a lot smarter. Adding error labels, link to specific runs and appropriate error logs.
@@ -37,3 +46,7 @@ ERROR: Task (virtual:native:/app/yocto/build/../poky/meta/recipes-support/sqlite
 <br>
 blabla error
 </details>
+
+
+# Code documentation
+Available [HERE](https://docs.rs/gh-workflow-parser/latest/gh_workflow_parser/)

--- a/justfile
+++ b/justfile
@@ -1,0 +1,29 @@
+[private]
+@default:
+    just --list
+
+# Needs the rust toolchain
+env:
+    rustc --version
+    cargo --version
+
+# Run the tests
+test:
+    cargo test
+
+# Build the application
+build *ARGS:
+    cargo build {{ ARGS }}
+
+
+# Run the application (use `--` to pass arguments to the application)
+run *ARGS:
+    cargo run {{ ARGS }}
+
+# Clean the `target` directory
+clean:
+    cargo clean
+
+# Build the documentation (use `--open` to open in the browser)
+doc *ARGS:
+    cargo doc {{ ARGS }}

--- a/justfile
+++ b/justfile
@@ -7,6 +7,14 @@ env:
     rustc --version
     cargo --version
 
+# Lint the code
+lint:
+    cargo clippy
+
+# Check if it compiles without compiling
+check:
+    cargo check
+
 # Run the tests
 test:
     cargo test
@@ -17,7 +25,7 @@ build *ARGS:
 
 
 # Run the application (use `--` to pass arguments to the application)
-run *ARGS:
+run ARGS:
     cargo run {{ ARGS }}
 
 # Clean the `target` directory

--- a/justfile
+++ b/justfile
@@ -11,6 +11,10 @@ env:
 lint:
     cargo clippy
 
+# Format the code
+format:
+    cargo fmt
+
 # Check if it compiles without compiling
 check:
     cargo check
@@ -35,3 +39,18 @@ clean:
 # Build the documentation (use `--open` to open in the browser)
 doc *ARGS:
     cargo doc {{ ARGS }}
+
+# Publish the crate
+publish:
+    cargo publish
+
+# List the dependencies
+deps:
+    cargo tree
+
+# Update the dependencies
+update:
+    cargo update
+
+# Run Full checks and format
+full-check: lint format check test

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -71,7 +71,7 @@ fn parse_to_gh_issue(
 }
 
 pub fn create_issue_from_failed_run(
-    github_cli: impl gh::GitHub,
+    github_cli: Box<dyn gh::GitHub>,
     run_id: &str,
     labels: &str,
     kind: WorkflowKind,

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,9 @@ pub struct Config {
     /// Debug flag to run through a scenario without making changes
     #[arg(long, default_value_t = false, global = true)]
     dry_run: bool,
+    /// Fake the GitHub CLI for testing
+    #[arg(long, default_value_t = false, global = true)]
+    fake_github_cli: bool,
     /// Verbosity level (0-4)
     #[arg(short, long, global = true, default_value_t = 2)]
     verbosity: u8,
@@ -39,6 +42,11 @@ impl Config {
     /// Get the dry run flag
     pub fn dry_run(&self) -> bool {
         self.dry_run
+    }
+
+    /// Get the fake GitHub CLI flag
+    pub fn fake_github_cli(&self) -> bool {
+        self.fake_github_cli
     }
 
     /// Get the subcommand

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -9,6 +9,33 @@ pub mod gh_cli;
 pub mod gh_cli_fake;
 pub mod util;
 
+/// Get the GitHub CLI and initialize it with a default repository
+/// If `fake` is true, a fake GitHub CLI is returned.
+/// The fake GitHub CLI is used for testing and does not interact with GitHub
+///
+/// # Arguments
+///
+/// * `repo` - The default repository to use
+/// * `fake` - If true, a fake GitHub CLI is returned
+///
+/// # Returns
+///
+/// [`Box<dyn GitHub>`](GitHub) - The GitHub CLI interface
+///
+/// # Example
+///
+/// ```
+/// # use gh_workflow_parser::gh::init_github_cli;
+/// let github_cli = init_github_cli("https://example.com/repo".to_string(), false);
+/// ```
+pub fn init_github_cli(repo: String, fake: bool) -> Box<dyn GitHub> {
+    if fake {
+        Box::new(gh_cli_fake::GitHubCliFake::new(repo))
+    } else {
+        Box::new(gh_cli::GitHubCli::new(repo))
+    }
+}
+
 /// Trait describing the methods that the GitHub CLI should implement
 pub trait GitHub {
     /// Get the summary of a run in a GitHub repository, if `repo` is `None` the default repository is used

--- a/src/gh/gh_cli.rs
+++ b/src/gh/gh_cli.rs
@@ -1,0 +1,73 @@
+use super::GitHub;
+
+#[derive(Debug, Default, Clone)]
+pub struct GitHubCli {
+    repo: String,
+}
+
+impl GitHubCli {
+    pub fn new(repo: String) -> Self {
+        Self { repo }
+    }
+}
+
+impl GitHub for GitHubCli {
+    fn run_summary(
+        &self,
+        repo: Option<&str>,
+        run_id: &str,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let target_repo = repo.unwrap_or(&self.repo);
+        super::run_summary(target_repo, run_id)
+    }
+
+    fn failed_job_log(
+        &self,
+        repo: Option<&str>,
+        job_id: &str,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let target_repo = repo.unwrap_or(&self.repo);
+        super::failed_job_log(target_repo, job_id)
+    }
+
+    fn create_issue(
+        &self,
+        repo: Option<&str>,
+        title: &str,
+        body: &str,
+        labels: &[String],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let target_repo = repo.unwrap_or(&self.repo);
+        super::create_issue(target_repo, title, body, labels)
+    }
+
+    fn issue_bodies_open_with_label(
+        &self,
+        repo: Option<&str>,
+        label: &str,
+    ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+        let target_repo = repo.unwrap_or(&self.repo);
+        super::issue_bodies_open_with_label(target_repo, label)
+    }
+
+    fn all_labels(&self, repo: Option<&str>) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+        let target_repo = repo.unwrap_or(&self.repo);
+        super::all_labels(target_repo)
+    }
+
+    fn create_label(
+        &self,
+        repo: Option<&str>,
+        name: &str,
+        color: &str,
+        description: &str,
+        force: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let target_repo = repo.unwrap_or(&self.repo);
+        super::create_label(target_repo, name, color, description, force)
+    }
+
+    fn default_repo(&self) -> &str {
+        &self.repo
+    }
+}

--- a/src/gh/gh_cli_fake.rs
+++ b/src/gh/gh_cli_fake.rs
@@ -18,9 +18,43 @@ impl GitHub for GitHubCliFake {
         run_id: &str,
     ) -> Result<String, Box<dyn std::error::Error>> {
         let target_repo = repo.unwrap_or(&self.repo);
-        Ok(format!(
-            "Fake run summary for repo={target_repo} and run_id={run_id}"
-        ))
+        log::info!("Fake run summary for repo={target_repo} and run_id={run_id}");
+
+        // Return a fake run summary from an actual run output
+        const TEST_OUTPUT_VIEW_RUN: &str = r#"
+    X master Use template and build image · 7858139663
+    Triggered via schedule about 10 hours ago
+
+    JOBS
+    ✓ enable-ssh-agent in 5s (ID 21442747661)
+    ✓ Test template raspberry in 19m20s (ID 21442749166)
+    X Test template xilinx in 5m41s (ID 21442749267)
+      ✓ Set up job
+      ✓ Log in to the Container registry
+      ✓ Cleanup build folder before start
+      ✓ Run actions/checkout@v4
+      ✓ Setup Rust and Just
+      ✓ 🗻 Make a templated project
+      ✓ ⚙️ Run new project setup steps
+      ✓ ⚒️ Build docker image
+      X 📦 Build yocto image
+      - 📩 Deploy image artifacts
+      ✓ Docker down
+      ✓ Cleanup build folder after done
+      ✓ Create issue on failure
+      ✓ Post Run actions/checkout@v4
+      ✓ Post Log in to the Container registry
+      ✓ Complete job
+
+    ANNOTATIONS
+    X Process completed with exit code 2.
+    Test template xilinx: .github#3839
+
+
+    To see what failed, try: gh run view 7858139663 --log-failed
+    View this run on GitHub: https://github.com/luftkode/distro-template/actions/runs/7858139663
+"#;
+        Ok(TEST_OUTPUT_VIEW_RUN.to_string())
     }
 
     fn failed_job_log(
@@ -29,9 +63,13 @@ impl GitHub for GitHubCliFake {
         job_id: &str,
     ) -> Result<String, Box<dyn std::error::Error>> {
         let target_repo = repo.unwrap_or(&self.repo);
-        Ok(format!(
-            "Fake failed job log for repo={target_repo} and job_id={job_id}"
-        ))
+        log::info!("Fake failed job log for repo={target_repo} and job_id={job_id}");
+        // Return a fake log from an actual run output
+        const TEST_LOG_STRING: &str = r#"Test template xilinx	📦 Build yocto image	2024-02-10T00:03:45.5797561Z ##[group]Run just --yes build-ci-image
+Test template xilinx	📦 Build yocto image	2024-02-10T00:03:45.5799911Z [36;1mjust --yes build-ci-image[0m
+Test template xilinx	📦 Build yocto image	2024-02-10T00:03:45.5843410Z shell: /usr/bin/bash -e {0}
+"#;
+        Ok(TEST_LOG_STRING.to_string())
     }
 
     fn create_issue(

--- a/src/gh/gh_cli_fake.rs
+++ b/src/gh/gh_cli_fake.rs
@@ -1,0 +1,86 @@
+use super::GitHub;
+
+#[derive(Debug, Default, Clone)]
+pub struct GitHubCliFake {
+    repo: String,
+}
+
+impl GitHubCliFake {
+    pub fn new(repo: String) -> Self {
+        Self { repo }
+    }
+}
+
+impl GitHub for GitHubCliFake {
+    fn run_summary(
+        &self,
+        repo: Option<&str>,
+        run_id: &str,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let target_repo = repo.unwrap_or(&self.repo);
+        Ok(format!(
+            "Fake run summary for repo={target_repo} and run_id={run_id}"
+        ))
+    }
+
+    fn failed_job_log(
+        &self,
+        repo: Option<&str>,
+        job_id: &str,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let target_repo = repo.unwrap_or(&self.repo);
+        Ok(format!(
+            "Fake failed job log for repo={target_repo} and job_id={job_id}"
+        ))
+    }
+
+    fn create_issue(
+        &self,
+        repo: Option<&str>,
+        title: &str,
+        body: &str,
+        labels: &[String],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let target_repo = repo.unwrap_or(&self.repo);
+        log::info!(
+            "Fake create_issue for repo={target_repo}, title={title}, body={body}, labels={labels:?}"
+        );
+        Ok(())
+    }
+
+    fn issue_bodies_open_with_label(
+        &self,
+        repo: Option<&str>,
+        label: &str,
+    ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+        let target_repo = repo.unwrap_or(&self.repo);
+        Ok(vec![format!(
+            "Fake issue body for repo={target_repo} and label={label}"
+        )])
+    }
+
+    fn all_labels(&self, repo: Option<&str>) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+        let target_repo = repo.unwrap_or(&self.repo);
+        log::info!("Fake all_labels for repo={target_repo}");
+        Ok(vec!["fake-label".to_string()])
+    }
+
+    fn create_label(
+        &self,
+        repo: Option<&str>,
+        name: &str,
+        color: &str,
+        description: &str,
+        force: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let target_repo = repo.unwrap_or(&self.repo);
+        log::info!(
+            "Fake create_label for repo={target_repo}, name={name}, color={color}, description={description}, force={force}"
+        );
+        Ok(())
+    }
+
+    fn default_repo(&self) -> &str {
+        &self.repo
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use gh_workflow_parser::{commands, config};
+use gh_workflow_parser::{commands, config, gh};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let config = config::init()?;
@@ -12,6 +12,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     log::info!("Parsing GitHub repository: {}", config.repo());
 
+    let github_cli = gh::gh_cli::GitHubCli::new(config.repo().to_owned());
+
     use commands::Command::*;
     match config.subcmd() {
         CreateIssueFromRun {
@@ -22,7 +24,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         } => {
             log::info!("Creating issue from failed run: {run_id}");
             commands::create_issue_from_failed_run(
-                config.repo().to_owned(),
+                github_cli,
                 run_id,
                 label,
                 *kind,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use gh_workflow_parser::{commands, config, gh};
+use gh_workflow_parser::{commands, config, gh::init_github_cli};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let config = config::init()?;
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     log::info!("Parsing GitHub repository: {}", config.repo());
 
-    let github_cli = gh::gh_cli::GitHubCli::new(config.repo().to_owned());
+    let github_cli = init_github_cli(config.repo().to_owned(), config.fake_github_cli());
 
     use commands::Command::*;
     match config.subcmd() {

--- a/tests/gh-workflow-parser.rs
+++ b/tests/gh-workflow-parser.rs
@@ -36,3 +36,31 @@ fn create_issue_from_failed_run_yocto() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+
+#[test]
+fn fake_github_cli_create_issue() -> Result<(), Box<dyn Error>> {
+    let mut cmd = Command::cargo_bin("gh-workflow-parser")?;
+
+    cmd.arg("--repo=fake-repo.com")
+        .arg("create-issue-from-run")
+        .arg("--run-id=1337")
+        .arg("--label=\"Random label\"")
+        .arg("--kind=yocto")
+        .arg("--fake-github-cli");
+
+    let std::process::Output {
+        status,
+        stdout: _,
+        stderr,
+    } = cmd.output()?;
+
+    let stderr = String::from_utf8(stderr)?;
+
+    assert!(status.success());
+
+    let stderr_contains_fn = predicate::str::contains("Fake create_issue for repo=fake-repo.com, title=Scheduled run failed, body=**Run ID**: 1337 [LINK TO RUN](fake-repo.com/actions/runs/1337)");
+
+    assert!(stderr_contains_fn.eval(&stderr));
+
+    Ok(())
+}


### PR DESCRIPTION
adds the trait (interface) **GitHub** that the GitHubCli struct implements.

Now the rest of the CLI uses the interface.

Adds:
- `--fake-github-cli` flag to use a fake/mock GitHub Cli instead of the real one, this allows more intelligent tests without making any API calls at all